### PR TITLE
Fixes the build errors from task.h and errors in the past PR.

### DIFF
--- a/FreeRTOS/Test/CMock/config/fake_port.h
+++ b/FreeRTOS/Test/CMock/config/fake_port.h
@@ -58,4 +58,7 @@ BaseType_t vFakePortCheckIfInISR( void );
 unsigned int vFakePortGetCoreID( void );
 void vFakePortYieldCore(int);
 
+UBaseType_t vFakePortEnterCriticalFromISR( void );
+void vFakePortExitCriticalFromISR( UBaseType_t uxSavedInterruptState );
+
 #endif /* FAKE_PORT_H */

--- a/FreeRTOS/Test/CMock/config/portmacro.h
+++ b/FreeRTOS/Test/CMock/config/portmacro.h
@@ -156,6 +156,9 @@ typedef unsigned long    UBaseType_t;
 #define portGET_CORE_ID()                vFakePortGetCoreID()
 #define portYIELD_CORE( x )              vFakePortYieldCore(x)
 
+#define portENTER_CRITICAL_FROM_ISR         vFakePortEnterCriticalFromISR
+#define portEXIT_CRITICAL_FROM_ISR          vFakePortExitCriticalFromISR
+
 #if ( configNUMBER_OF_CORES > 1 )
     #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
     #define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/FreeRTOSConfig.h
@@ -153,7 +153,4 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
     #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
 #endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
 
-#define portENTER_CRITICAL_FROM_ISR()       ( 0 )
-#define portEXIT_CRITICAL_FROM_ISR( x )     do{ ( void )( x ); }while( 0 )
-
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/FreeRTOSConfig.h
@@ -153,7 +153,4 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
     #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
 #endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
 
-#define portENTER_CRITICAL_FROM_ISR()       ( 0 )
-#define portEXIT_CRITICAL_FROM_ISR( x )     do{ ( void )( x ); }while( 0 )
-
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
@@ -153,7 +153,4 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
     #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
 #endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
 
-#define portENTER_CRITICAL_FROM_ISR()       ( 0 )
-#define portEXIT_CRITICAL_FROM_ISR( x )     do{ ( void )( x ); }while( 0 )
-
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 
 /* SMP test specific configuration */
 #define configRUN_MULTIPLE_PRIORITIES                    0
-#define configNUMBER_OF_CORES                            16
+#define configNUMBER_OF_CORES                            4
 #define configUSE_CORE_AFFINITY                          1
 #define configUSE_TIME_SLICING                           1
 #define configUSE_TASK_PREEMPTION_DISABLE                0

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 
 /* SMP test specific configuration */
 #define configRUN_MULTIPLE_PRIORITIES                    0
-#define configNUMBER_OF_CORES                            4
+#define configNUMBER_OF_CORES                            16
 #define configUSE_CORE_AFFINITY                          1
 #define configUSE_TIME_SLICING                           1
 #define configUSE_TASK_PREEMPTION_DISABLE                0

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.c
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.c
@@ -332,7 +332,6 @@ void verifySmpTask( TaskHandle_t * xTaskHandle, eTaskState eCurrentState, TaskRu
     TaskStatus_t xTaskDetails;
 
     vTaskGetInfo(*xTaskHandle, &xTaskDetails, pdTRUE, eInvalid );
-    //printf("xTaskDetails.xHandle->xTaskRunState: %ld, xTaskRunState: %ld \n", xTaskDetails.xHandle->xTaskRunState, xTaskRunState);
     TEST_ASSERT_EQUAL_INT_MESSAGE(xTaskRunState, xTaskDetails.xHandle->xTaskRunState, "Task Verification Failed: Incorrect xTaskRunState");
     TEST_ASSERT_EQUAL_INT_MESSAGE( eCurrentState, xTaskDetails.eCurrentState, "Task Verification Failed: Incorrect eCurrentState" );
 }

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.h
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.h
@@ -86,4 +86,9 @@ void verifyIdleTask( BaseType_t index, TaskRunning_t xTaskRunState);
  */
 void vSmpTestTask( void *pvParameters );
 
+/**
+ * @brief Helper function to simulate calling xTaskIncrementTick in critical section.
+ */
+void xTaskIncrementTick_helper(void);
+
 #endif /* SMP_UTEST_COMMON_H */

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
@@ -136,4 +136,5 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 #define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO        0
 #define configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES    0
 
+
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -66,7 +66,6 @@ extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
 
-//#message "Before the critical section"
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
     #define xYieldPending   xYieldPendings[ 0 ]

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -65,7 +65,6 @@ extern volatile TickType_t xTickCount;
 extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
-
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
     #define xYieldPending   xYieldPendings[ 0 ]

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -65,16 +65,19 @@ extern volatile TickType_t xTickCount;
 extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
-#if ( defined( configNUM_CORES ) && ( configNUM_CORES == 1 ) )
+
+//#message "Before the critical section"
+#if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
     #define xYieldPending   xYieldPendings[ 0 ]
 #else
     extern volatile BaseType_t xYieldPending;
 #endif
+
 extern volatile BaseType_t xNumOfOverflows;
 extern UBaseType_t uxTaskNumber;
 extern volatile TickType_t xNextTaskUnblockTime;
-#if ( defined( configNUM_CORES ) && ( configNUM_CORES == 1 ) )
+#if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern TaskHandle_t xIdleTaskHandles[];
     #define xIdleTaskHandle   xIdleTaskHandles[ 0 ]
 #else

--- a/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
@@ -64,7 +64,7 @@ extern volatile TickType_t xTickCount;
 extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
-#if ( defined( configNUM_CORES ) && ( configNUM_CORES == 1 ) )
+#if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
     #define xYieldPending   xYieldPendings[ 0 ]
 #else
@@ -73,7 +73,7 @@ extern volatile TickType_t xPendedTicks;
 extern volatile BaseType_t xNumOfOverflows;
 extern UBaseType_t uxTaskNumber;
 extern volatile TickType_t xNextTaskUnblockTime;
-#if ( defined( configNUM_CORES ) && ( configNUM_CORES == 1 ) )
+#if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern TaskHandle_t xIdleTaskHandles[];
     #define xIdleTaskHandle   xIdleTaskHandles[ 0 ]
 #else


### PR DESCRIPTION
<!--- Title -->
Fixes the build errors from task.h and errors in the past [PR](https://github.com/joshzarr/FreeRTOS/pull/2)
Description
-----------
- Adding a helper function to call xTaskIncrementTick in critical section
- Make use of the return value of xTaskIncrementTick to yield the core calling this function
- Update test cases correspondingly
- Fixes the comments on the past PR and build failure caused from the tasks test folder

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
