### PR TITLE
Add raise running task priority test cases

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -314,80 +314,6 @@ void test_priority_change_tasks_equal_priority_raise( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
- * A task of equal priority will be created for each available CPU core. An
- * additional task will be created in the ready state at equal priority.
- * This test will verify that when the priority of running task is raised all
- * the other running tasks remain running.
- *
- * #define configRUN_MULTIPLE_PRIORITIES                    1
- * #define configUSE_TIME_SLICING                           0
- * #define configUSE_CORE_AFFINITY                          1
- * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * #define configNUMBER_OF_CORES                            (N > 1)
- *
- * This test can be run with FreeRTOS configured for any number of cores
- * greater than 1.
- *
- * Tasks are created prior to starting the scheduler.
- *
- * Task (T1)	    Task (TN)       Task (TN+1)
- * Priority – 2     Priority – 2    Priority – 2
- * State - Ready    State - Ready   State - Ready
- *
- * After calling vTaskStartScheduler()
- *
- * Task (T1)	        Task (TN)           Task (TN+1)
- * Priority – 2         Priority – 2        Priority – 2
- * State - Running      State - Running     State - Ready
- *
- * After calling vTaskPrioritySet() and raising the priority of task T1
- *
- * Task (T1)	        Task (TN)           Task (TN+1)
- * Priority – 3         Priority – 2        Priority – 2
- * State - Running      State - Running     State - Ready
- */
-void test_priority_change_extra_tasks_equal_priority_raise( void )
-{
-    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
-    uint32_t i;
-    TaskStatus_t xTaskDetails;
-
-    /* Create tasks at equal priority. */
-    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
-    {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
-    }
-
-    vTaskStartScheduler();
-
-    /* Verify each task is in the running state. */
-    for( i = 0; i < configNUMBER_OF_CORES; i++ )
-    {
-        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
-    }
-
-    /* Verify the last task is in the ready state. */
-    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
-
-    /* Raise the priority of a running task. */
-    vTaskPrioritySet( xTaskHandles[ 0 ], 3 );
-
-    /* Verify the priority has been changed. */
-    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
-    TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
-
-    /* Verify each task is in the running state. */
-    for( i = 0; i < configNUMBER_OF_CORES; i++ )
-    {
-        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
-    }
-
-    /* Verify the last task is in the ready state */
-    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
-}
-
-/**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-37
  * A task of high priority will be created for each available CPU core. An
  * additional task will be created in the ready state at low priority.
@@ -704,6 +630,78 @@ void test_priority_change_tasks_different_priority_lower_to_lowest( void )
     }
 
     verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-110
+ * A task of equal priority will be created for each available CPU core. An
+ * additional task will be created in the ready state at equal priority.
+ * This test will verify that when the priority of running task is raised all
+ * the other running tasks remain running.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           0
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
+ * greater than 1.
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (T1)	    Task (TN)       Task (TN+1)
+ * Priority – 1     Priority – 1    Priority – 1
+ * State - Ready    State - Ready   State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	        Task (TN)           Task (TN+1)
+ * Priority – 1         Priority – 1        Priority – 1
+ * State - Running      State - Running     State - Ready
+ *
+ * After calling vTaskPrioritySet() and raising the priority of task T1
+ *
+ * Task (T1)	        Task (TN)           Task (TN+1)
+ * Priority – 2         Priority – 1        Priority – 1
+ * State - Running      State - Running     State - Ready
+ */
+void test_priority_change_tasks_equal_priority_raise_additional_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+    TaskStatus_t xTaskDetails;
+
+    /* Create tasks at equal priority. */
+    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify each task is in the running state. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the last task is in the ready state. */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
+    /* Raise the priority of a running task. */
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
+
+    /* Verify the priority has been changed. */
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
+
+    /* Verify each task is in the running state. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the last task is in the ready state */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
@@ -321,7 +321,7 @@ void test_priority_change_tasks_equal_priority_raise( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-111
  * A task of priority higher than idle is created. The test verify that when the priority
  * of the task is raised, running idle task won't be altered.
  *
@@ -342,28 +342,28 @@ void test_priority_change_tasks_equal_priority_raise( void )
  *
  * Task (T1)                Idle task (1)               Idle task (N)
  * Priority – 1             Priority – idle             Priority – idle
- * State - Running (Core 0) State - Running (Core 1)    State - ready
+ * State - Running (Core 1) State - Running (Core 2)    State - ready
  *
  * After calling vTaskPrioritySet() and raising the priority of task T1
  *
  * Task (T1)                Idle task (1)              Idle task (N)
- * Priority – 1             Priority – idle            Priority – idle
+ * Priority – 2             Priority – idle            Priority – idle
  * State - Running (Core 0) State - Running (Core 1)   State - ready
  */
-void test_priority_change_tasks_priority_raise( void )
+void test_priority_change_task_high_priority_raise( void )
 {
-    TaskHandle_t xTaskHandle = { NULL };
+    TaskHandle_t xTaskHandles[ 1 ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create a task to run. */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandle );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ 0 ] );
 
     /* Start scheduler. */
     vTaskStartScheduler();
 
     /* Verify the task is running. */
-    verifySmpTask( &xTaskHandle, eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
     for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {
         /* Verify the idle task is running on all other CPU cores */
@@ -371,14 +371,14 @@ void test_priority_change_tasks_priority_raise( void )
     }
 
     /* Raise the priority of the running task. */
-    vTaskPrioritySet( xTaskHandle, 2 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandle, &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the task is still in the running state */
-    verifySmpTask( &xTaskHandle, eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
     for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
@@ -321,6 +321,73 @@ void test_priority_change_tasks_equal_priority_raise( void )
 }
 
 /**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * A task of priority higher than idle is created. The test verify that when the priority
+ * of the task is raised, running idle task won't be altered.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    0
+ * #define configUSE_TIME_SLICING                           0
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
+ * greater than 1.
+ *
+ * A Task is created prior to starting the scheduler.
+ *
+ * Task (T1)
+ * Priority – 1
+ * State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)                Idle task (1)               Idle task (N)
+ * Priority – 1             Priority – idle             Priority – idle
+ * State - Running (Core 0) State - Running (Core 1)    State - ready
+ *
+ * After calling vTaskPrioritySet() and raising the priority of task T1
+ *
+ * Task (T1)                Idle task (1)              Idle task (N)
+ * Priority – 1             Priority – idle            Priority – idle
+ * State - Running (Core 0) State - Running (Core 1)   State - ready
+ */
+void test_priority_change_tasks_priority_raise( void )
+{
+    TaskHandle_t xTaskHandle = { NULL };
+    uint32_t i;
+    TaskStatus_t xTaskDetails;
+
+    /* Create a task to run. */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandle );
+
+    /* Start scheduler. */
+    vTaskStartScheduler();
+
+    /* Verify the task is running. */
+    verifySmpTask( &xTaskHandle, eRunning, 0 );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        /* Verify the idle task is running on all other CPU cores */
+        verifyIdleTask( i - 1, i );
+    }
+
+    /* Raise the priority of the running task. */
+    vTaskPrioritySet( xTaskHandle, 2 );
+
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandle, &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
+
+    /* Verify the task is still in the running state */
+    verifySmpTask( &xTaskHandle, eRunning, 0 );
+
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        /* Verify the idle task is still running on the same core. */
+        verifyIdleTask( i - 1, i );
+    }
+}
+
+/**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-5
  * A single task of high priority will be created. A low priority task will be
  * created for each remaining available CPU core. The test will first verify


### PR DESCRIPTION
Adding the functional tests to verify this kernel PR https://github.com/chinglee-iot/FreeRTOS-Kernel/pull/72 is merged.

Description
-----------
* Add test_priority_change_task_high_priority_raise in single priority no timeslice. This test verify that raising the priority of a running task won't alter the idle tasks.
* Add test_priority_change_tasks_equal_priority_raise_additional_task in multiple priority no timeslice. This test verify that raising the priority of a running task won't alter other running tasks.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
