### PR TITLE
Add priority inherit and disinerit test cases

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -3186,7 +3186,7 @@ void test_task_yield_run_equal_priority_new_task( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-106
  * Task can inherit or disinherit other higher priority task. This test verify that
  * lower priority task will be selected to run when it inherit a higher priorirty task.
  * The lower priority will be switched out when it disinherits higher priority task.
@@ -3287,7 +3287,7 @@ void test_task_priority_inherit_disinherit( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-107
  * Task can inherit or disinherit other higher priority task. This test verify that
  * lower priority task will be selected to run when it inherit a higher priorirty task.
  * The lower priority will be switched out when it is disinherited by higher priority
@@ -3318,7 +3318,7 @@ void test_task_priority_inherit_disinherit( void )
  * Priority – 3       Priority – 2      Priority – 2    Priority – 3
  * State – Running    State – Running   State – Ready   State – Running
  *
- * Task TN+1 is disinherited by Task T1 due to timeout
+ * Task TN+1 is disinherited by task T1 due to timeout
  *
  * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
  * Priority – 3       Priority – 2      Priority – 2    Priority – 1

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -3185,6 +3185,45 @@ void test_task_yield_run_equal_priority_new_task( void )
     verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }
 
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * Task can inherit or disinherit other higher priority task. This test verify that
+ * lower priority task will be selected to run when it inherit a higher priorirty task.
+ * The lower priority will be switched out when it disinherits higher priority task.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           0
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater
+ * than 1.
+ *
+ * Tasks are created prior to starting the scheduler
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Ready	  State – Ready     State – Ready   State – Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Running    State – Running   State – Running State – Ready
+ *
+ * Assuming task TN+1 is holding a mutex. Task TN+1 inherits task T1's priority
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 3
+ * State – Running    State – Running   State – Ready   State – Running
+ *                                                      uxMutexesHeld - 1
+ *
+ * Task TN+1 disinherits task T1's priority.
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Running    State – Running   State – Running State – Ready
+ *                                                      uxMutexesHeld - 0
+ */
 void test_task_priority_inherit_disinherit( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
@@ -3214,7 +3253,7 @@ void test_task_priority_inherit_disinherit( void )
     /* Verify the low priority task is ready. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    /* Assuming the low priority is helding a mutex. */
+    /* Assuming the low priority task is holding a mutex. */
     xTaskHandles[ configNUMBER_OF_CORES ]->uxMutexesHeld = 1;
 
     /* Low priority task inherit current core task priority, which is the high priority task. */
@@ -3234,6 +3273,9 @@ void test_task_priority_inherit_disinherit( void )
     }
     taskEXIT_CRITICAL();
 
+    /* Verify the mutex held count is decreased. */
+    TEST_ASSERT_EQUAL( 0U, xTaskHandles[ configNUMBER_OF_CORES ]->uxMutexesHeld );
+
     /* Verify the high and medium priority tasks running. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
@@ -3244,6 +3286,44 @@ void test_task_priority_inherit_disinherit( void )
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 }
 
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * Task can inherit or disinherit other higher priority task. This test verify that
+ * lower priority task will be selected to run when it inherit a higher priorirty task.
+ * The lower priority will be switched out when it is disinherited by higher priority
+ * task due to timeout.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           0
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater
+ * than 1.
+ *
+ * Tasks are created prior to starting the scheduler
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Ready	  State – Ready     State – Ready   State – Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Running    State – Running   State – Running State – Ready
+ *
+ * Assuming task TN+1 is holding a mutex. Task TN+1 inherits task T1's priority
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 3
+ * State – Running    State – Running   State – Ready   State – Running
+ *
+ * Task TN+1 is disinherited by Task T1 due to timeout
+ *
+ * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
+ * Priority – 3       Priority – 2      Priority – 2    Priority – 1
+ * State – Running    State – Running   State – Running State – Ready
+ */
 void test_task_priority_inherit_disinherit_timeout( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
@@ -3273,7 +3353,7 @@ void test_task_priority_inherit_disinherit_timeout( void )
     /* Verify the low priority task is ready. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    /* Assuming the low priority is helding a mutex. */
+    /* Assuming the low priority task is holding a mutex. */
     xTaskHandles[ configNUMBER_OF_CORES ]->uxMutexesHeld = 1;
 
     /* Low priority task inherit current core task priority, which is the high priority task. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -3228,6 +3228,7 @@ void test_task_priority_inherit_disinherit( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
+    TaskStatus_t xTaskDetails;
 
     /* Create 1 high priority task. */
     xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ 0 ] );
@@ -3263,6 +3264,10 @@ void test_task_priority_inherit_disinherit( void )
     }
     taskEXIT_CRITICAL();
 
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
+
     /* Verify that the low priority task is running on last core. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
@@ -3272,6 +3277,10 @@ void test_task_priority_inherit_disinherit( void )
         xTaskPriorityDisinherit( xTaskHandles[ configNUMBER_OF_CORES ] );
     }
     taskEXIT_CRITICAL();
+
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the mutex held count is decreased. */
     TEST_ASSERT_EQUAL( 0U, xTaskHandles[ configNUMBER_OF_CORES ]->uxMutexesHeld );
@@ -3328,6 +3337,7 @@ void test_task_priority_inherit_disinherit_timeout( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
+    TaskStatus_t xTaskDetails;
 
     /* Create 1 high priority task. */
     xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ 0 ] );
@@ -3363,6 +3373,10 @@ void test_task_priority_inherit_disinherit_timeout( void )
     }
     taskEXIT_CRITICAL();
 
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
+
     /* Verify that the low priority task is running on last core. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
@@ -3372,6 +3386,10 @@ void test_task_priority_inherit_disinherit_timeout( void )
         vTaskPriorityDisinheritAfterTimeout( xTaskHandles[ configNUMBER_OF_CORES ], 1 );
     }
     taskEXIT_CRITICAL();
+
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the high and medium priority tasks running. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
@@ -2328,7 +2328,7 @@ void test_task_block_all_cores_equal_priority_block_running( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-108
  * Task can inherit or disinherit other higher priority task. This test verify that
  * lower priority task will be selected to run when it inherit a higher priorirty task.
  * The lower priority will be switched out when it disinherits higher priority task.
@@ -2429,7 +2429,7 @@ void test_task_priority_inherit_disinherit( void )
 }
 
 /**
- * @brief AWS_IoT-FreeRTOS_SMP_TC-<TBD>
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-109
  * Task can inherit or disinherit other higher priority task. This test verify that
  * lower priority task will be selected to run when it inherit a higher priorirty task.
  * The lower priority will be switched out when it is disinherited by higher priority
@@ -2460,7 +2460,7 @@ void test_task_priority_inherit_disinherit( void )
  * Priority – 3       Priority – 2      Priority – 2    Priority – 3
  * State – Running    State – Ready     State – Ready   State – Running
  *
- * Task TN+1 is disinherited by Task T1 due to timeout
+ * Task TN+1 is disinherited by task T1 due to timeout
  *
  * Task (T1)	      Task (T2)         Task (TN)       Task (TN + 1)
  * Priority – 3       Priority – 2      Priority – 2    Priority – 1

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
@@ -2370,6 +2370,7 @@ void test_task_priority_inherit_disinherit( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
+    TaskStatus_t xTaskDetails;
 
     /* Create 1 high priority task. */
     xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ 0 ] );
@@ -2405,6 +2406,10 @@ void test_task_priority_inherit_disinherit( void )
     }
     taskEXIT_CRITICAL();
 
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
+
     /* Verify that the low priority task is running on last core. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
@@ -2414,6 +2419,10 @@ void test_task_priority_inherit_disinherit( void )
         xTaskPriorityDisinherit( xTaskHandles[ configNUMBER_OF_CORES ] );
     }
     taskEXIT_CRITICAL();
+
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the mutex held count is decreased. */
     TEST_ASSERT_EQUAL( 0U, xTaskHandles[ configNUMBER_OF_CORES ]->uxMutexesHeld );
@@ -2470,6 +2479,7 @@ void test_task_priority_inherit_disinherit_timeout( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
+    TaskStatus_t xTaskDetails;
 
     /* Create 1 high priority task. */
     xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ 0 ] );
@@ -2505,6 +2515,10 @@ void test_task_priority_inherit_disinherit_timeout( void )
     }
     taskEXIT_CRITICAL();
 
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
+
     /* Verify that the low priority task is running on last core. */
     verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
@@ -2514,6 +2528,10 @@ void test_task_priority_inherit_disinherit_timeout( void )
         vTaskPriorityDisinheritAfterTimeout( xTaskHandles[ configNUMBER_OF_CORES ], 1 );
     }
     taskEXIT_CRITICAL();
+
+    /* Verify the priority has been changed */
+    vTaskGetInfo( xTaskHandles[ configNUMBER_OF_CORES ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the high priority task is running. */
     verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );


### PR DESCRIPTION
Add priority inherit and disinherit test cases

Description
-----------
xTaskPriorityInherit, xTaskPriorityDisinherit and vTaskPriorityDisinheritAfterTimeout need to yield the inherited/disinherited task.

Adding the following test cases to verify the result:
* test_task_priority_inherit_disinherit
* test_task_priority_inherit_disinherit_timeout

Also add the coverage test for the following APIs due to submodule updated:
* prvSearchForNameWithinSingleList

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 99.7% | 1456 / 1461 | 100.0 % | 95 / 95 | 96.2 % | 1002 / 1042
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
