### PR TITLE
Add multiple priority timeslice test group

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
@@ -73,7 +73,7 @@
 #define configUSE_QUEUE_SETS                             1
 #define configUSE_TASK_NOTIFICATIONS                     1
 #define configTASK_NOTIFICATION_ARRAY_ENTRIES            5
-#define configSUPPORT_STATIC_ALLOCATION                  1
+#define configSUPPORT_STATIC_ALLOCATION                  0
 #define configSUPPORT_DYNAMIC_ALLOCATION                 1
 #define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 )
 #define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
@@ -887,7 +887,7 @@ void test_task_create_tasks_lower_priority( void )
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-102
- * A high priority task will be created for each available CPU core. This test will
+ * A low priority task will be created for each available CPU core. This test will
  * verify that as OS ticks are generated all tasks will execute on a fixed CPU core.
  * A new high priority task will be created. The test will then verify the new task
  * is running and remain tasks rotate on cores.

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
@@ -143,12 +143,19 @@ void test_timeslice_verification_tasks_equal_priority( void )
 
     /* Generate a tick for each configNUMBER_OF_CORES. This will cause each
      * task to be either moved to the ready state or the running state */
-    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    for( i = 0; i <= configNUMBER_OF_CORES; i++ )
     {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core or enters the ready state */
-        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+        if( i < configNUMBER_OF_CORES )
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+        }
+        else
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+        }
     }
 }
 
@@ -225,7 +232,7 @@ void test_timeslice_verification_idle_core( void )
  * will verify that as OS ticks are generated all CPU cores will remain running
  * their original tasks and the ready task never enters the running state.
  *
- * #define configRUN_MULTIPLE_PRIORITIES                    0
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
@@ -944,7 +951,7 @@ void test_task_create_tasks_higher_priority( void )
         }
     }
 
-    /* Create a new low priority task */
+    /* Create a new high priority task */
     xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ configNUMBER_OF_CORES ] );
 
     /* Verify the created task is running on the last core. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
@@ -48,6 +48,10 @@
 #include "mock_fake_assert.h"
 #include "mock_fake_port.h"
 
+/* ===========================  EXTERN VARIABLES  =========================== */
+
+extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
+
 /* ============================  Unity Fixtures  ============================ */
 /*! called before each testcase */
 void setUp( void )
@@ -72,4 +76,1421 @@ int suiteTearDown( int numFailures )
     return numFailures;
 }
 
+/* =============================  HELPER FUNCTIONS  ========================= */
+void vApplicationMinimalIdleHook( void )
+{
+    /* Adding this function to pass compilation. */
+}
+
 /* ==============================  Test Cases  ============================== */
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-89
+ * A task of equal priority will be created for each available CPU core. An
+ * additional task will be created in the ready state. This test will verify
+ * that as OS ticks are generated the ready task will be made to run on each
+ * CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)	    Task (TN + 1)
+ * Priority – 1     Priority – 1
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)	               Task (TN + 1)
+ * Priority – 1                Priority – 1
+ * State - Running (Core N)	   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ */
+void test_timeslice_verification_tasks_equal_priority( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES + 1 tasks of equal priority */
+    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all configNUMBER_OF_CORES tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the last task is in the ready state */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
+    /* Generate a tick for each configNUMBER_OF_CORES. This will cause each
+     * task to be either moved to the ready state or the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core or enters the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-90
+ * A task of equal priority will be created for each available CPU core
+ * except for one. This will leave a CPU core running the idle task. This test
+ * will verify that as OS ticks are generated the tasks will remain on the same
+ * CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN - 1)
+ * Priority – 1
+ * State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN - 1)
+ * Priority – 1
+ * State - Running (Core N - 1)
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN - 1)
+ * Priority – 1
+ * State - Running (Core N - 1)
+ */
+void test_timeslice_verification_idle_core( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
+    uint32_t i;
+
+    /* Create ( configNUMBER_OF_CORES - 1 ) tasks of equal priority */
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state prior to incrementing a tick */
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the idle task is running on the last CPU Core */
+    verifyIdleTask( 0, ( configNUMBER_OF_CORES - 1 ) );
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES - 1; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-91
+ * A high priority task will be created for each available CPU core. An
+ * additional low priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all CPU cores will remain running
+ * their original tasks and the ready task never enters the running state.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    0
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)	    Task (TN + 1)
+ * Priority – 2     Priority – 1
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ */
+void test_timeslice_verification_different_priority_tasks( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of high priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single low priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    /* The low priority task should never enter the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-103
+ * A low priority task will be created for each available CPU core. An additional
+ * High priority task will be created in the ready state. This test will verify that
+ * as OS ticks are generated the high priority task remains running. The low priority
+ * tasks rotate on cores.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (T1)        Task (TN)	    Task (TN + 1)
+ * Priority – 2     Priority – 1    Priority – 1
+ * State - Ready    State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)        Task (TN)	    Task (TN + 1)
+ * Priority – 2     Priority – 1    Priority – 1
+ * State - Running  State - Running	State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The high priority task
+ * remains running. The low priority tasks rotate on cores.
+ */
+void test_timeslice_verification_low_priority_tasks_rotate( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create 1 task with high priority. */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
+
+    /* Create configNUMBER_OF_CORES tasks of low priority */
+    for( i = 1; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state except TN+1. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    /* Verify low priority tasks rotate on cores each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
+
+        if( ( i + 1 ) == configNUMBER_OF_CORES )
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+        }
+        else
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i + 1 );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-104
+ * A high priority task will be created for each available CPU core. An
+ * additional low priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all CPU cores will remain running
+ * their original tasks and the ready task never enters the running state. The
+ * test will then increase the priority of the ready task and verify tasks now
+ * begin to run on each CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1.
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)	    Task (TN + 1)
+ * Priority – 2     Priority – 1
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ *
+ * Raise the priority of task TN + 1 and verify on each tick it executes on a
+ * different CPU core
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ */
+void test_priority_change_tasks_different_priority_raise_to_equal( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of high priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single low priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    /* The low priority task should never enter the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+    }
+
+    /* Raise the priority of the low priority task to match the running tasks */
+    vTaskPrioritySet( xTaskHandles[ configNUMBER_OF_CORES ], 2 );
+
+    /* After the first tick the ready task will be running on the first CPU core */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
+         * the last state of -1 is omitted */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-93
+ * A low priority task will be created for each available CPU core. This test will
+ * verify that as OS ticks are generated all CPU cores will remain running their original
+ * tasks. The test will then increase the priority of the first task and verify tasks
+ * remain running on original core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1.
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)	    Task (TN)
+ * Priority – 1     Priority – 1
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	              Task (TN)
+ * Priority – 1               Priority – 1
+ * State - Running (Core 1)   State - Running (Core N)
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (T1)	              Task (TN)
+ * Priority – 1               Priority – 1
+ * State - Running (Core 1)   State - Running (Core N)
+ *
+ * Raise the priority of task T1 and verify on each tick the running state is not changed.
+ *
+ * Task (T1)	              Task (TN)
+ * Priority – 2               Priority – 1
+ * State - Running (Core 1)   State - Running (Core N)
+ */
+void test_priority_change_tasks_equal_priority_raise_to_high( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of low priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify all the tasks are still in the running state after system ticks. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+
+    /* Raise the priority of the first task. */
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
+
+    /* Verify all the tasks are still in the running state after system ticks. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-105
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all tasks will execute on each
+ * CPU core. The test will then lower the priority of the last task and verify
+ * tasks now remain running on a dedicated CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)	    Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 2
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ *
+ * Lower the priority of task TN + 1
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)	              Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ */
+void test_priority_change_tasks_equal_priority_lower_ready_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core. */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+
+    /* Lower the priority of the last ready task. */
+    vTaskPrioritySet( xTaskHandles[ configNUMBER_OF_CORES ], 1 );
+
+    /* Verify all configNUMBER_OF_CORES tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+        }
+
+        /* Verify the low priority task remains in the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-94
+ * A high priority task will be created for each available CPU core. This test will
+ * verify that as OS ticks are generated all tasks will execute on each CPU core.
+ * The test will then lower the priority of the last task and verify tasks now remain
+ * running on a dedicated CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (T1)	    Task (TN)
+ * Priority – 2     Priority – 2
+ * State - Ready	State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	              Task (TN)
+ * Priority – 2               Priority – 2
+ * State - Running (Core 1)   State - Running (Core N)
+ *
+ * Lower the priority of task TN.
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (T1)	              Task (TN)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Running (Core N)
+ */
+void test_priority_change_tasks_equal_priority_lower_running_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES  ] = { NULL };
+    uint32_t i,j;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify that all the tasks are in the running state after system ticks. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+
+    /* Lower the priority of the last core. */
+    vTaskPrioritySet( xTaskHandles[ configNUMBER_OF_CORES - 1 ], 1 );
+
+    /* Verify that all the tasks are still in the running state after system ticks. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-95
+ * A task will be created for each available CPU core. This test will verify that as
+ * OS ticks are generated all tasks will execute on a fixed CPU core. A new task
+ * will be created. The test will then verify tasks now execute on each
+ * available CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)
+ * Priority – 1
+ * State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)
+ * Priority – 1
+ * State - Running (Core N)
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)
+ * Priority – 1
+ * State - Running (Core N)
+ *
+ * Create a new task
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ */
+void test_task_create_tasks_equal_priority( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+
+    /* Create a new task of equal priority */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    /* Verify the last created task runs on each core or enters the ready state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /*
+         * Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
+         * the last state of -1 is omitted
+         */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-96
+ * A high priority task will be created for each available CPU core. This test
+ * will verify that as OS ticks are generated all tasks will execute on a fixed
+ * CPU core. A new low priority task will be created. The test will then verify
+ * the tasks remain executing on the original CPU cores and do not rotate.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Running (Core N)
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Running (Core N)
+ *
+ * Create a new low priority task
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN)                  Task (TN + 1)
+ * Priority – 2               Priority – 1
+ * State - Running (Core N)   State - Ready
+ */
+void test_task_create_tasks_lower_priority( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+
+    /* Create a new low priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-102
+ * A high priority task will be created for each available CPU core. This test will
+ * verify that as OS ticks are generated all tasks will execute on a fixed CPU core.
+ * A new high priority task will be created. The test will then verify the new task
+ * is running and remain tasks rotate on cores.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (T1)            Task (TN)
+ * Priority – 1         Priority – 1
+ * State - Ready        State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)            Task (TN)
+ * Priority – 1         Priority – 1
+ * State - Running      State - Running
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (T1)            Task (TN)
+ * Priority – 1         Priority – 1
+ * State - Running      State - Running
+ *
+ * Create a new high priority task
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The created task remains running.
+ * The other tasks rotate on cores.
+ *
+ * Task (T1)        Task (TN)       Task (TN+1)
+ * Priority – 1     Priority – 1    Priority – 2
+ * State - Running  State - Ready   State - Running
+ */
+void test_task_create_tasks_higher_priority( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+    uint32_t j;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
+        }
+    }
+
+    /* Create a new low priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    /* Verify the created task is running on the last core. */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        if( i != ( configNUMBER_OF_CORES - 1 ) )
+        {
+            verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+        }
+        else
+        {
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+        }
+    }
+
+    /* Verify the high priority task running on the last core. Other lower priority tasks
+     * rotate on cores. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
+
+        /* Verify the lower priority tasks rotate. */
+        if( i < ( configNUMBER_OF_CORES - 1 ) )
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES - i - 2 ], eReady, -1 );
+        }
+        else
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES - 1 ], eReady, -1 );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-97
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all tasks will execute on each
+ * CPU core. A task will be deleted. The test will then verify the tasks remain
+ * executing on fixed CPU cores and do not rotate.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)      Task (TN + 1)
+ * Priority – 2   Priority – 2
+ * State - Ready  State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)                  Task (TN + 1)
+ * Priority – 2               Priority – 2
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ *
+ * Delete the last created task
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Running
+ */
+void test_task_delete_tasks_equal_priorities_delete_running_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core or enters the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+
+    /* Delete last task.
+     * Before ready list : [ 1(0), 2(1), ..., N(N-1), 0 ]
+     * After ready list : [ 1(0), 2(1), ..., 0(N-1) ]
+     */
+    vTaskDelete( xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    /* Verify all configNUMBER_OF_CORES tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+        }
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-98
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all tasks will execute on each
+ * CPU core. A task will be suspended. The test will then verify the tasks remain
+ * executing on fixed CPU cores and do not rotate. When the suspended task is
+ * resumed it will begin executing on each CPU core on each tick.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)      Task (TN + 1)
+ * Priority – 2   Priority – 2
+ * State - Ready  State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)                  Task (TN + 1)
+ * Priority – 2               Priority – 2
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ *
+ * Suspend the last created task
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Running (Core N)
+ *
+ * Resume the suspended task. The tasks will now rotate to each CPU on each tick.
+ */
+void test_task_suspend_running_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core or enters the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+
+    /* Suspend last task.
+     * Before ready list : [ 1(0), 2(1), ..., N(N-1), 0 ]
+     * After ready list : [ 1(0), 2(1), ..., 0(N-1) ]
+     */
+    vTaskSuspend( xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    /* Verify all tasks remain in the running state each time a tick is incremented */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+        }
+    }
+
+    /* Resume suspended task.
+     * Before ready list : [ 1(0), 2(1), ..., 0(N-1) ]
+     * After ready list : [ 1(0), 2(1), ..., 0(N-1), N ]
+     */
+    vTaskResume( xTaskHandles[ configNUMBER_OF_CORES ] );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
+         * the last state of -1 is omitted
+         */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-99
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all tasks will execute on each
+ * CPU core. A task will be blocked. The test will then verify the tasks remain
+ * executing on fixed CPU cores and do not rotate.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)      Task (TN + 1)
+ * Priority – 2   Priority – 2
+ * State - Ready  State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)                  Task (TN + 1)
+ * Priority – 2               Priority – 2
+ * State - Running (Core N)   State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (0) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ *
+ * Block the task running on core 0, which is task 1.
+ *
+ * Call xTaskIncrementTick() for each configured CPU core. The tasks will not
+ * change state.
+ *
+ * Task (TN)
+ * Priority – 2
+ * State - Running
+ *
+ * After blocking the task, verify task 1 can be scheduled on each core.
+ */
+void test_task_block_running_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core or enters the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+
+    /* Block the first task on core 0, which is task 1.
+     * Before ready list : [ 0, 1(0), 2(1), ..., N(N-1) ]
+     * After ready list : [ 0(0), 2(1), ..., N(N-1) ]
+     */
+    vTaskDelay( configNUMBER_OF_CORES + 1 );
+
+    /* Verify all configNUMBER_OF_CORES tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            if( j == 0 )
+            {
+                verifySmpTask( &xTaskHandles[ j ], eRunning, 0 );
+            }
+            else if( j == 1 )
+            {
+                /* Task 1 is currently been blocked. */
+                verifySmpTask( &xTaskHandles[ j ], eBlocked, -1 );
+            }
+            else
+            {
+                verifySmpTask( &xTaskHandles[ j ], eRunning, j - 1 );
+            }
+        }
+    }
+
+    /* After ( configNUMBER_OF_CORES + 1 ) ticks, the task 1 will be added back to
+     * the ready list. Verfiy that the task 1 can be scheduled on each core when
+     * xTaskIncrementTick is called. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /*
+         * Verify the the task 1 has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
+         * the last state of -1 is omitted
+         */
+        verifySmpTask( &xTaskHandles[ 1 ], eRunning, i );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-100
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created with affinity for the largest
+ * numbered CPU core. This test will verify that as OS ticks are generated the
+ * task with CPU affinity will either be in the ready state or running on the
+ * specified CPU core.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)        Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * Affinity – None  Affinity – Last CPU Core
+ * State - Ready    State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)        Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * Affinity – None  Affinity – Last CPU Core
+ * State - Running  State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       3
+ * 2      -1
+ * 3       3
+ * 4      -1
+ *
+ */
+void test_task_affinity_verification( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task with core affinity for the last CPU core */
+    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, ( 1 << ( configNUMBER_OF_CORES - 1 ) ), &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the task is either in the ready state or running on the last CPU core */
+        int32_t core = ( i % 2 == 0 ) ? ( configNUMBER_OF_CORES - 1 ) : -1;
+
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], ( core == -1 ) ? eReady : eRunning, core );
+    }
+}
+
+/**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-101
+ * A high priority task will be created for each available CPU core. An
+ * additional high priority task will be created in the ready state. This test
+ * will verify that as OS ticks are generated all tasks will execute on each
+ * CPU core. The test will then set the last task to have affinity for the last
+ * CPU core. The last task will only run on the last CPU core or be in the ready
+ * state.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           1
+ * #define configUSE_CORE_AFFINITY                          1
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (TN)        Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * Affinity – None  Affinity – None
+ * State - Ready    State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (TN)        Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * Affinity – None  Affinity – None
+ * State - Running  State - Ready
+ *
+ * Call xTaskIncrementTick() for each configured CPU core.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1       0
+ * 2       1
+ * 3       2
+ * 4       3
+ *
+ * Set affinity for the last task to the last CPU core.
+ *
+ * Task (TN)        Task (TN + 1)
+ * Priority – 2     Priority – 2
+ * Affinity – None  Affinity – Last CPU Core
+ * State - Running  State - Ready
+ *
+ * Verify the task only runs on the specified core or is in the ready state.
+ *
+ * Task (TN + 1) when configNUMBER_OF_CORES = 4
+ * Tick    Core
+ * 1      -1
+ * 2       3
+ * 3      -1
+ * 4       3
+ */
+void test_task_affinity_set_affinity_running_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+
+    /* Create configNUMBER_OF_CORES tasks of equal priority */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+
+    vTaskStartScheduler();
+
+    /* Verify all tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* The remaining task shall be in the ready state */
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+
+    /* After the first tick the ready task will be running on CPU core 1 */
+    int32_t core = 1;
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the last created task runs on each core or enters the ready state */
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+    }
+
+    /* Set CPU core affinity on the last task for the last CPU core */
+    vTaskCoreAffinitySet( xTaskHandles[ configNUMBER_OF_CORES ], 1 << ( configNUMBER_OF_CORES - 1 ) );
+
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskIncrementTick_helper();
+
+        /* Verify the task is either in the ready state or running on the last CPU core */
+        core = ( i % 2 == 1 ) ? ( configNUMBER_OF_CORES - 1 ) : -1;
+
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], ( core == -1 ) ? eReady : eRunning, core );
+    }
+}

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
@@ -431,7 +431,7 @@ void test_priority_change_tasks_different_priority_raise_to_equal( void )
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
  */
-void test_priority_change_tasks_equal_priority( void )
+void test_priority_change_tasks_equal_priority_lower_ready_task( void )
 {
     TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
@@ -143,12 +143,19 @@ void test_timeslice_verification_tasks_equal_priority( void )
 
     /* Generate a tick for each configNUMBER_OF_CORES. This will cause each
      * task to be either moved to the ready state or the running state */
-    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    for( i = 0; i <= configNUMBER_OF_CORES; i++ )
     {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core or enters the ready state */
-        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+        if( i < configNUMBER_OF_CORES )
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
+        }
+        else
+        {
+            verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
+        }
     }
 }
 


### PR DESCRIPTION
Add multiple priority timeslice test group

Description
-----------
The test result with configNUMBER_OF_CORES = 16
```
# run each test case
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/build/bin/smp_multiple_priorities_timeslice_multiple_priorities_timeslice_utest /mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/build/bin/smp_multiple_priorities_timeslice_covg_multiple_priorities_timeslice_utest
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:122:test_timeslice_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:187:test_timeslice_verification_idle_core:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:253:test_timeslice_verification_different_priority_tasks:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:322:test_timeslice_verification_low_priority_tasks_rotate:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:409:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:500:test_priority_change_tasks_equal_priority_raise_to_high:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:589:test_priority_change_tasks_equal_priority_lower_ready_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:674:test_priority_change_tasks_equal_priority_lower_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:762:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:842:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:922:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1029:test_task_delete_tasks_equal_priorities_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1127:test_task_suspend_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1241:test_task_block_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1357:test_task_affinity_verification:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1448:test_task_affinity_set_affinity_running_task:PASS

-----------------------
16 Tests 0 Failures 0 Ignored
```

Test result with configNUMBER_OF_CORES = 4
```
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:122:test_timeslice_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:194:test_timeslice_verification_idle_core:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:260:test_timeslice_verification_different_priority_tasks:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:329:test_timeslice_verification_low_priority_tasks_rotate:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:416:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:507:test_priority_change_tasks_equal_priority_raise_to_high:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:596:test_priority_change_tasks_equal_priority_lower_ready_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:681:test_priority_change_tasks_equal_priority_lower_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:769:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:849:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:929:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1036:test_task_delete_tasks_equal_priorities_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1134:test_task_suspend_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1248:test_task_block_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1364:test_task_affinity_verification:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1455:test_task_affinity_set_affinity_running_task:PASS

-----------------------
16 Tests 0 Failures 0 Ignored
```


Test result with configNUMBER_OF_CORES = 2
```
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:122:test_timeslice_verification_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:187:test_timeslice_verification_idle_core:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:253:test_timeslice_verification_different_priority_tasks:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:322:test_timeslice_verification_low_priority_tasks_rotate:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:409:test_priority_change_tasks_different_priority_raise_to_equal:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:500:test_priority_change_tasks_equal_priority_raise_to_high:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:589:test_priority_change_tasks_equal_priority_lower_ready_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:674:test_priority_change_tasks_equal_priority_lower_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:762:test_task_create_tasks_equal_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:842:test_task_create_tasks_lower_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:922:test_task_create_tasks_higher_priority:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1029:test_task_delete_tasks_equal_priorities_delete_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1127:test_task_suspend_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1241:test_task_block_running_task:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1357:test_task_affinity_verification:PASS
/mnt/c/msys64/home/chinglee/smp/josh/FreeRTOS/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c:1448:test_task_affinity_set_affinity_running_task:PASS

-----------------------
16 Tests 0 Failures 0 Ignored
```


Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
