### PR TITLE
Fix the hardcoded core number in the test

### DIFF
--- a/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
+++ b/FreeRTOS/Test/CMock/smp/config_assert/config_assert_utest.c
@@ -238,7 +238,7 @@ void test_prvCheckForRunStateChange_asssert_runstate_ne_task_yield( void )
  */
 void test_prvYieldForTask_assert_critical_nesting_lteq_zero( void )
 {
-    UBaseType_t uxCoreAffinityMask = 8;
+    UBaseType_t uxCoreAffinityMask;
     TCB_t currentTCB;
 
     memset( &currentTCB, 0x00, sizeof( TCB_t ) );
@@ -247,6 +247,9 @@ void test_prvYieldForTask_assert_critical_nesting_lteq_zero( void )
     pxCurrentTCBs[ 0 ]->uxCoreAffinityMask = 1;
     pxCurrentTCBs[ 0 ]->uxCriticalNesting = 0;
     pxCurrentTCBs[ 0 ]->xTaskRunState = -1; /* taskTASK_NOT_RUNNING */
+
+    /* Set the new mask to the last core. */
+    uxCoreAffinityMask = ( 1 << ( configNUMBER_OF_CORES - 1 ) );
 
     vFakePortEnterCriticalSection_Expect();
     vFakePortGetCoreID_ExpectAndReturn( 0 );

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/covg_multiple_priorities_no_timeslice_mock_utest.c
@@ -311,7 +311,7 @@ void test_coverage_vTaskSuspend_running_state_above_range( void )
 
     /* Validation. */
     TEST_ASSERT_EQUAL( pdFALSE, xYieldPendings[ 0 ] );
-    TEST_ASSERT_EQUAL( 17, pxCurrentTCBs[ 0 ]->xTaskRunState );
+    TEST_ASSERT_EQUAL( configNUMBER_OF_CORES + 1, pxCurrentTCBs[ 0 ]->xTaskRunState );
 }
 
 /**
@@ -347,7 +347,7 @@ void test_coverage_vTaskPrioritySet_non_running_state( void )
     vTaskPrioritySet( &xTaskTCBs[ 0 ], 2 );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( 17, xTaskTCBs[ 0 ].xTaskRunState );
+    TEST_ASSERT_EQUAL( configNUMBER_OF_CORES + 1, xTaskTCBs[ 0 ].xTaskRunState );
     TEST_ASSERT_EQUAL( 2, xTaskTCBs[ 0 ].uxPriority );
 }
 


### PR DESCRIPTION
Fix some of the coverage test which use hard coded core numbers.

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
Set configNUMBER_OF_CORES to number other than 16 should not have any failure test cases.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
